### PR TITLE
Update GitHub Actions and push to Harbor registry

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -3,20 +3,26 @@ name: harbor
 on:
   push:
     branches: main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (default: latest)'
+        required: false
+        default: 'latest'
 
 jobs:
-  
+
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
-    
+
       - name: Checkout
-        uses: actions/checkout@v4.2.2
-      
+        uses: actions/checkout@v4
+
       - name: Login to harbor
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v3
         with:
           registry: harbor.cyverse.org
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -24,27 +30,27 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      
+
       - name: Build and push latest
         id: docker_build_latest
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6
         with:
-          context: latest 
+          context: latest
           file: latest/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: harbor.cyverse.org/vice/vscode:latest
+          tags: harbor.cyverse.org/vice/vscode:${{ github.event.inputs.tag || 'latest' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${{ steps.docker_build_latest.outputs.digest }}


### PR DESCRIPTION
- Update action versions to major tags (v4, v3, v6) for automatic security patches
- Add workflow_dispatch for manual triggering with optional tag input
- Fix image digest output to reference correct step id
- Push image to harbor.cyverse.org/vice/vscode with configurable tag